### PR TITLE
Fixed case-sensitive call to Gdip_all.ahk on main script

### DIFF
--- a/Verity_Fireteam_Image_Maker_v1.0.1.ahk
+++ b/Verity_Fireteam_Image_Maker_v1.0.1.ahk
@@ -2,7 +2,7 @@ SetWorkingDir, %A_ScriptDir%
 #SingleInstance, force
 CoordMode, Pixel, Screen
 CoordMode, Mouse, Screen
-#include Gdip_All.ahk
+#include Gdip_all.ahk
 pToken := Gdip_Startup()
 
 if (!FileExist(A_ScriptDir "\Bin"))


### PR DESCRIPTION
**Main Change:**
The main script is referring to Gdip_all.ahk as upper case, which throws an error. Changing the script to lower case fixes the issue.  Without the change, AHK complaints that Gdip_All.ahk cannot be found.

**Test**
* Tested changes on Windows 10 machine.

**Observations**
Sorry I couldn't find info on pull-requests, so I hope this is ok.