### PR TITLE
Set default value for delay

### DIFF
--- a/Verity_Fireteam_Image_Maker_v1.0.1.ahk
+++ b/Verity_Fireteam_Image_Maker_v1.0.1.ahk
@@ -13,6 +13,9 @@ return
 F3::
 {
     InputBox, delay_time, Fireteam Image Maker, Input the amount of time to wait after inspecting a player.`nDefault: 2000`nIncrease this number if loading slowly.
+    if (delay_time = "") {
+        delay_time := 2000 ; default value
+    }
     Send u
     Sleep 1000
 


### PR DESCRIPTION
- set delay_time for 2000ms as default value if the user does not enter a value (wants to leave the specified default value)